### PR TITLE
Merge v2.1.16 into develop (updates SDK libraries for v0.18.0)

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "2.1.15"
+  "version": "2.1.16"
 }

--- a/packages/mymonero-monero-client/package-lock.json
+++ b/packages/mymonero-monero-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mymonero/mymonero-monero-client",
-  "version": "2.1.14",
+  "version": "2.1.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mymonero/mymonero-monero-client",
-      "version": "2.1.14",
+      "version": "2.1.16",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "chai": "^4.3.4",

--- a/packages/mymonero-monero-client/package.json
+++ b/packages/mymonero-monero-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mymonero/mymonero-monero-client",
-  "version": "2.1.14",
+  "version": "2.1.16",
   "description": "The JS library containing the JS transpilation of the shared library behind the MyMonero apps",
   "main": "./src/index.js",
   "scripts": {

--- a/packages/mymonero-wallet-manager/package-lock.json
+++ b/packages/mymonero-wallet-manager/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@mymonero/mymonero-wallet-manager",
-	"version": "2.1.14",
+	"version": "2.1.16",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@mymonero/mymonero-wallet-manager",
-			"version": "2.1.14",
+			"version": "2.1.16",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@mymonero/mymonero-monero-client": "^2.1.1",

--- a/packages/mymonero-wallet-manager/package.json
+++ b/packages/mymonero-wallet-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mymonero/mymonero-wallet-manager",
-  "version": "2.1.14",
+  "version": "2.1.16",
   "description": "",
   "main": "src/WalletManager.js",
   "scripts": {
@@ -10,7 +10,7 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "@mymonero/mymonero-lws-client": "^2.1.14",
-    "@mymonero/mymonero-monero-client": "^2.1.14",
+    "@mymonero/mymonero-monero-client": "^2.1.16",
     "bignumber.js": "^9.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This merge updates mymonero-wallet-manager and mymonero-monero-client to be compatible with the latest hard fork. 

The WASM and accompanying .JS file are both located in packages/mymonero-monero-client. The SHA hashes of these files are as follows:

Full commit hash: d156bb3d77905b606f6a16109efd837cf

File: MyMoneroClient_WASM.wasm
SHA1: e54ebfc04839c763cbdb6e60383fb0a2fd16874b
SHA256: 7114318836a3be9aa80f4cbe88bfd5dcc5264fc6127c554d9cae9a1eb52ec484

File: MyMoneroClient_WASM.js
SHA1: f3988a9aea4e1f6e1d61c5feb78f77e04e2fde83
SHA256: 8d4676325b12dc1e4ba41cd397a1b1099f67206a70fead76f5ad525b3be11bd3